### PR TITLE
Make it easy to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.egg*
+.env2
+.env3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# run the tests for python2 and python3
+test: .env2 .env3
+	@$(MAKE) test2
+	@$(MAKE) test3
+
+# run tests for python 2
+test2: .env2
+	.env2/bin/python runtests.py
+
+# run tests for python 3
+test3: .env3
+	.env3/bin/python runtests.py
+
+# remove junk
+clean:
+	rm -rf .env2 .env3
+	find -iname "*.pyc" -or -iname "__pycache__" -delete
+
+# setup a virtualenv for python2
+.env2:
+	virtualenv --no-site-packages -p python .env2
+	.env2/bin/pip install -e .[test]
+
+# setup a virtualenv for python3 and install pip
+.env3:
+	python3 -m venv .env3
+	curl https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py | .env3/bin/python
+	.env3/bin/pip install -e .[test]

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ class Foo(models.Model, SearchMixin):
         attribute_fields = (‘name’,)
 ```
 See comments in models.py for more documentation on use
+
+Tests:
+-----
+To run the test suite for Python 2 and Python 3:
+
+    make test
+
+It is assumed you have a `virtualenv` in your path, and Elasticsearch running
+on localhost:9200

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,42 @@
+import sys
+
+import django
+from django.conf import settings
+
+
+settings.configure(
+    DEBUG=True,
+    DATABASES={
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+        }
+    },
+    INSTALLED_APPS=(
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.admin',
+        'elastic_models',
+    ),
+    MIDDLEWARE_CLASSES=[],
+    ELASTICSEARCH_CONNECTIONS={
+        'default': {
+            'HOSTS': ['http://localhost:9200'],
+            'INDEX_NAME': 'elastic_models',
+        }
+    }
+)
+
+if django.VERSION[:2] >= (1, 7):
+    from django import setup
+else:
+    setup = lambda: None
+
+from elastic_models.tests import DefaultSearchRunner
+
+setup()
+test_runner = DefaultSearchRunner(verbosity=1)
+
+failures = test_runner.run_tests(['elastic_models', ])
+if failures:
+    sys.exit(failures)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools import find_packages, setup
 
 setup(
@@ -6,5 +7,8 @@ setup(
     install_requires=['elasticsearch','elasticsearch-dsl'],
     packages=find_packages(),
     long_description=open('README.md').read(),
-    author='Andrew Stoneman'
+    author='Andrew Stoneman',
+    extras_require={
+        'test': ["django" + ("<1.7" if sys.version_info[:2] < (2, 7) else "")],
+    }
 )


### PR DESCRIPTION
We ought to have an easier way to run the unit tests. This is the code I've been using on other shared packages.

If #5 gets merged in, `runtests.py` will need to be updated with the name of the test runner.
